### PR TITLE
Switch themes based on OS settings

### DIFF
--- a/src/__tests__/store/actions/settings.test.js
+++ b/src/__tests__/store/actions/settings.test.js
@@ -17,7 +17,17 @@ describe('settings actions', () => {
     expect(actions.setTheme(theme)).toEqual({
       type: 'SET_THEME',
       payload: {
-        theme
+        userTheme: theme
+      }
+    })
+  })
+
+  test('setPreferredTheme creates action to set browser preffered theme', () => {
+    const theme = 'MOCK_THEME'
+    expect(actions.setPreferredTheme(theme)).toEqual({
+      type: 'SET_PREFERRED_THEME',
+      payload: {
+        preferredTheme: theme
       }
     })
   })
@@ -41,6 +51,13 @@ describe('settings actions', () => {
     expect(darkStyle.getAttribute('disabled')).toEqual('disabled')
     expect(body.className).toEqual('theme-light')
     expect(localStorage.getItem('theme')).toEqual('theme-light')
+
+    actions.setTheme('theme-auto')
+
+    expect(lightStyle.getAttribute('disabled')).toEqual(null)
+    expect(darkStyle.getAttribute('disabled')).toEqual('disabled')
+    expect(body.className).toEqual('theme-light')
+    expect(localStorage.getItem('theme')).toEqual('theme-auto')
 
     actions.setTheme('invalid-theme')
 

--- a/src/__tests__/store/reducers/settings.test.js
+++ b/src/__tests__/store/reducers/settings.test.js
@@ -2,17 +2,35 @@ import settingsReducer from 'src/store/reducers/settings'
 
 describe('settings reducer', () => {
   test('returns initial state', () => {
-    expect(settingsReducer(undefined, {})).toEqual({ theme: 'theme-light' })
+    expect(settingsReducer(undefined, {})).toEqual({
+      userTheme: 'theme-light',
+      preferredTheme: 'theme-light'
+    })
   })
 
   test('handles SET_THEME', () => {
     const action = {
       type: 'SET_THEME',
       payload: {
-        theme: 'mock-theme'
+        userTheme: 'mock-theme'
       }
     }
 
-    expect(settingsReducer({}, action)).toEqual({ theme: action.payload.theme })
+    expect(settingsReducer({}, action)).toEqual({
+      userTheme: action.payload.userTheme
+    })
+  })
+
+  test('handles SET_PREFERRED_THEME', () => {
+    const action = {
+      type: 'SET_PREFERRED_THEME',
+      payload: {
+        preferredTheme: 'mock-theme'
+      }
+    }
+
+    expect(settingsReducer({}, action)).toEqual({
+      preferredTheme: action.payload.preferredTheme
+    })
   })
 })

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -94,7 +94,9 @@ class Editor extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const colorScheme = this.props.theme
+    const { theme } = this.props
+    const colorScheme =
+      theme.userTheme === 'theme-auto' ? theme.preferredTheme : theme.userTheme
 
     if (prevProps.theme !== colorScheme && this.monaco) {
       this.monaco.setTheme(this.getTheme(colorScheme))
@@ -133,6 +135,8 @@ class Editor extends React.Component {
     })
 
     const model = monaco.createModel(content, language)
+    const editorTheme =
+      theme.userTheme === 'theme-auto' ? theme.preferredTheme : theme.userTheme
 
     this.editor = monaco.create(this.editorRef.current, {
       model,
@@ -143,7 +147,7 @@ class Editor extends React.Component {
       },
       automaticLayout: true,
       fontSize: 14,
-      theme: this.getTheme(theme),
+      theme: this.getTheme(editorTheme),
       renderIndentGuides: false
     })
 
@@ -246,12 +250,15 @@ Editor.propTypes = {
   language: PropTypes.string.isRequired,
   fileName: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
-  theme: PropTypes.oneOf(['theme-light', 'theme-dark']).isRequired,
+  theme: PropTypes.shape({
+    userTheme: PropTypes.oneOf(['theme-light', 'theme-dark', 'theme-auto']),
+    preferredTheme: PropTypes.oneOf(['theme-light', 'theme-dark'])
+  }),
   onForceRender: PropTypes.func.isRequired
 }
 
 const mapStateToProps = state => ({
-  theme: state.settings.theme
+  theme: state.settings
 })
 
 export default connect(mapStateToProps)(Editor)

--- a/src/components/LandingScreen.js
+++ b/src/components/LandingScreen.js
@@ -33,7 +33,7 @@ const LandingScreen = ({ theme }) => {
 }
 
 LandingScreen.propTypes = {
-  theme: PropTypes.oneOf(['theme-dark', 'theme-light'])
+  theme: PropTypes.oneOf(['theme-dark', 'theme-light', 'theme-auto'])
 }
 
 const mapStateToProps = state => ({

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { VscGithub } from 'react-icons/vsc'
 import { login, logout, loadProfileFromStorage } from '../store/actions/user'
-import { setTheme } from '../store/actions/settings'
+import { setPreferredTheme, setTheme } from '../store/actions/settings'
 
 const Settings = props => {
   const { isLoggedIn, username, isLoading } = props
@@ -14,12 +14,21 @@ const Settings = props => {
   const toggleTheme = theme => {
     setCurrentTheme(theme)
     props.setTheme(theme)
+
+    if (theme === 'theme-auto') {
+      const query = window.matchMedia('(prefers-color-scheme: dark)')
+
+      if (query.matches) {
+        props.setPreferredTheme('theme-dark')
+      } else {
+        props.setPreferredTheme('theme-light')
+      }
+    }
   }
 
   useEffect(() => {
     const profile = JSON.parse(localStorage.getItem('profile'))
     setCurrentTheme(localStorage.getItem('theme'))
-    console.log(currentTheme)
     if (profile) {
       props.loadProfileFromStorage({
         accessToken: profile.accessToken,
@@ -87,7 +96,8 @@ const mapDispatchToProps = {
   login,
   logout,
   loadProfileFromStorage,
-  setTheme
+  setTheme,
+  setPreferredTheme
 }
 
 const mapStateToProps = state => ({
@@ -95,7 +105,7 @@ const mapStateToProps = state => ({
   username: state.user.username,
   isLoading: state.user.isLoading,
   rateLimit: state.user.rateLimit,
-  theme: state.settings.theme
+  theme: state.settings
 })
 
 Settings.propTypes = {
@@ -106,7 +116,11 @@ Settings.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadProfileFromStorage: PropTypes.func.isRequired,
   setTheme: PropTypes.func.isRequired,
-  theme: PropTypes.oneOf(['theme-dark', 'theme-light', 'theme-auto']).isRequired
+  setPreferredTheme: PropTypes.func.isRequired,
+  theme: PropTypes.shape({
+    userTheme: PropTypes.oneOf[('theme-dark', 'theme-light', 'theme-auto')],
+    preferredTheme: PropTypes.oneOf[('theme-dark', 'theme-light')]
+  })
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Settings)

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -1,5 +1,5 @@
 import '../style/settings.scss'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { VscGithub } from 'react-icons/vsc'
@@ -9,17 +9,17 @@ import { setTheme } from '../store/actions/settings'
 const Settings = props => {
   const { isLoggedIn, username, isLoading } = props
   const action = isLoggedIn ? props.logout : props.login
+  const [currentTheme, setCurrentTheme] = useState('theme-auto')
 
-  const toggleTheme = () => {
-    const isDark = document.body.className === 'theme-dark'
-    const theme = isDark ? 'theme-light' : 'theme-dark'
-
+  const toggleTheme = theme => {
+    setCurrentTheme(theme)
     props.setTheme(theme)
   }
 
   useEffect(() => {
     const profile = JSON.parse(localStorage.getItem('profile'))
-
+    setCurrentTheme(localStorage.getItem('theme'))
+    console.log(currentTheme)
     if (profile) {
       props.loadProfileFromStorage({
         accessToken: profile.accessToken,
@@ -30,9 +30,32 @@ const Settings = props => {
 
   return (
     <div className="settings">
-      <button className="theme-toggle-btn" onClick={toggleTheme}>
-        {props.theme === 'theme-dark' ? 'Light mode' : 'Dark mode'}
-      </button>
+      <div className="segmented-btn">
+        <button
+          className={`theme-toggle-btn ${
+            currentTheme === 'theme-dark' ? 'selected' : ''
+          }`}
+          onClick={() => toggleTheme('theme-dark')}
+        >
+          Dark
+        </button>
+        <button
+          className={`theme-toggle-btn ${
+            currentTheme === 'theme-light' ? 'selected' : ''
+          }`}
+          onClick={() => toggleTheme('theme-light')}
+        >
+          Light
+        </button>
+        <button
+          className={`theme-toggle-btn ${
+            currentTheme === 'theme-auto' ? 'selected' : ''
+          }`}
+          onClick={() => toggleTheme('theme-auto')}
+        >
+          Auto
+        </button>
+      </div>
       <button
         className={`login-btn ${isLoading ? 'is-loading' : ''}`}
         onClick={action}
@@ -83,7 +106,7 @@ Settings.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadProfileFromStorage: PropTypes.func.isRequired,
   setTheme: PropTypes.func.isRequired,
-  theme: PropTypes.oneOf(['theme-dark', 'theme-light']).isRequired
+  theme: PropTypes.oneOf(['theme-dark', 'theme-light', 'theme-auto']).isRequired
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(Settings)

--- a/src/components/renderers/MarkdownRenderer.js
+++ b/src/components/renderers/MarkdownRenderer.js
@@ -197,11 +197,14 @@ class MarkdownRenderer extends React.Component {
 
 MarkdownRenderer.propTypes = {
   content: PropTypes.string.isRequired,
-  theme: PropTypes.oneOf(['theme-dark', 'theme-light']).isRequired
+  theme: PropTypes.shape({
+    userTheme: PropTypes.oneOf(['theme-light', 'theme-dark', 'theme-auto']),
+    preferredTheme: PropTypes.oneOf(['theme-light', 'theme-dark'])
+  })
 }
 
 const mapStateToProps = state => ({
-  theme: state.settings.theme
+  theme: state.settings
 })
 
 export default connect(mapStateToProps)(MarkdownRenderer)

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,15 @@ const updateFavicon = isDark => {
   document.querySelector('link[rel="icon"]').setAttribute('href', link)
 }
 
-query.addEventListener('change', event => updateFavicon(event.matches))
+query.addEventListener('change', event => {
+  updateFavicon(event.matches)
+
+  if (event.matches) {
+    store.dispatch(setTheme('theme-dark'))
+  } else {
+    store.dispatch(setTheme('theme-light'))
+  }
+})
 
 if (theme) {
   store.dispatch(setTheme(theme))

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import App from './components/App'
 import { Provider } from 'react-redux'
 import store from './store'
 import ModalRoot from './components/ModalRoot'
-import { setTheme } from './store/actions/settings'
+import { setPreferredTheme, setTheme } from './store/actions/settings'
 
 if (module.hot) {
   module.hot.accept()
@@ -19,6 +19,16 @@ const updateFavicon = isDark => {
   document.querySelector('link[rel="icon"]').setAttribute('href', link)
 }
 
+const updatePrefferedTheme = query => {
+  if (query.matches) {
+    store.dispatch(setPreferredTheme('theme-dark'))
+  } else {
+    store.dispatch(setPreferredTheme('theme-light'))
+  }
+}
+
+updatePrefferedTheme(query)
+
 query.addEventListener('change', event => {
   updateFavicon(event.matches)
 
@@ -26,11 +36,7 @@ query.addEventListener('change', event => {
     return
   }
 
-  if (event.matches) {
-    store.dispatch(setTheme('theme-dark'))
-  } else {
-    store.dispatch(setTheme('theme-light'))
-  }
+  updatePrefferedTheme(event)
 })
 
 if (theme) {

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,10 @@ const updateFavicon = isDark => {
 query.addEventListener('change', event => {
   updateFavicon(event.matches)
 
+  if (localStorage.getItem('theme') !== 'theme-auto') {
+    return
+  }
+
   if (event.matches) {
     store.dispatch(setTheme('theme-dark'))
   } else {

--- a/src/store/actions/settings.js
+++ b/src/store/actions/settings.js
@@ -1,29 +1,16 @@
 import Logger from '../../scripts/logger'
 
-const setTheme = theme => {
+const applyTheme = theme => {
   // Query light/dark themes for highlight.js so we can enable/disable
   // stylesheets when the app theme changes
   const lightStyle = document.querySelector('link[title="theme-light"]')
   const darkStyle = document.querySelector('link[title="theme-dark"]')
   const body = document.body
 
-  localStorage.setItem('theme', theme)
-
-  let reifiedTheme = theme
-  if (theme === 'theme-auto') {
-    const query = window.matchMedia('(prefers-color-scheme: dark)').matches
-    if (query) {
-      reifiedTheme = 'theme-dark'
-      return
-    }
-
-    reifiedTheme = 'theme-light'
-  }
-
   body.classList.toggle(body.className)
-  body.classList.add(reifiedTheme)
+  body.classList.add(theme)
 
-  switch (reifiedTheme) {
+  switch (theme) {
     case 'theme-light':
       darkStyle.setAttribute('disabled', 'disabled')
       lightStyle.removeAttribute('disabled')
@@ -35,13 +22,32 @@ const setTheme = theme => {
     default:
       Logger.warn('Unknown theme', theme)
   }
+}
+
+const setTheme = theme => {
+  localStorage.setItem('theme', theme)
+
+  if (theme !== 'theme-auto') {
+    applyTheme(theme)
+  }
 
   return {
     type: 'SET_THEME',
     payload: {
-      theme
+      userTheme: theme
     }
   }
 }
 
-export { setTheme }
+const setPreferredTheme = theme => {
+  applyTheme(theme)
+
+  return {
+    type: 'SET_PREFERRED_THEME',
+    payload: {
+      preferredTheme: theme
+    }
+  }
+}
+
+export { setTheme, setPreferredTheme }

--- a/src/store/actions/settings.js
+++ b/src/store/actions/settings.js
@@ -9,10 +9,21 @@ const setTheme = theme => {
 
   localStorage.setItem('theme', theme)
 
-  body.classList.toggle(body.className)
-  body.classList.add(theme)
+  let reifiedTheme = theme
+  if (theme === 'theme-auto') {
+    const query = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (query) {
+      reifiedTheme = 'theme-dark'
+      return
+    }
 
-  switch (theme) {
+    reifiedTheme = 'theme-light'
+  }
+
+  body.classList.toggle(body.className)
+  body.classList.add(reifiedTheme)
+
+  switch (reifiedTheme) {
     case 'theme-light':
       darkStyle.setAttribute('disabled', 'disabled')
       lightStyle.removeAttribute('disabled')

--- a/src/store/reducers/settings.js
+++ b/src/store/reducers/settings.js
@@ -1,5 +1,6 @@
 const initialState = {
-  theme: 'theme-light'
+  userTheme: 'theme-light',
+  preferredTheme: 'theme-light'
 }
 
 const reducer = (state = initialState, action) => {
@@ -8,7 +9,13 @@ const reducer = (state = initialState, action) => {
   switch (action.type) {
     case 'SET_THEME':
       return {
-        theme: payload.theme
+        userTheme: payload.userTheme,
+        preferredTheme: state.preferredTheme
+      }
+    case 'SET_PREFERRED_THEME':
+      return {
+        userTheme: state.userTheme,
+        preferredTheme: payload.preferredTheme
       }
     default:
       return state

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -37,6 +37,7 @@
   --color-scrollbar-native: #bebebe;
 
   --color-folder: #79b8ff;
+  --color-selected: #0366d6;
 }
 
 .theme-dark {
@@ -68,6 +69,7 @@
   --color-scrollbar-native: #696969;
 
   --color-folder: #6e7681;
+  --color-selected: #58a6ff;
 }
 
 body {

--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -39,12 +39,23 @@
     }
 
     &.selected {
-      background-color: blue;
+      color: white;
+      border-radius: 0;
+      background-color: var(--color-selected);
     }
   }
 
   .segmented-btn {
+    border: 1px solid var(--color-border);
     display: flex;
+    border-radius: 3px;
+    overflow: hidden;
+    margin-bottom: 0.8em;
+
+    & > button {
+      margin-bottom: 0;
+      border-radius: 0 !important;
+    }
   }
 
   .theme-toggle-btn {

--- a/src/style/settings.scss
+++ b/src/style/settings.scss
@@ -37,6 +37,14 @@
         background-color: var(--color-list-item-hover);
       }
     }
+
+    &.selected {
+      background-color: blue;
+    }
+  }
+
+  .segmented-btn {
+    display: flex;
   }
 
   .theme-toggle-btn {


### PR DESCRIPTION
Allows for the website to adapt it's color theme based on OS settings, this is nice for people (like me) who have their OS color settings change based on the time of day. 

The selection for the color themes is now a segmented button group with three options:
Light & Dark: For manually light and dark modes
Auto: Uses the OS color theme

Demo:

https://user-images.githubusercontent.com/77477100/117356085-5b420680-ae81-11eb-8360-320f32afa9bb.mov




